### PR TITLE
Fix lint errors by improving typings

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -14,7 +14,7 @@ export interface Inmate {
   unit?: Unit
   requests?: InmateRequest[]
   comments?: InmateComment[]
-  [key: string]: any // Allow other properties
+  [key: string]: unknown // Allow other properties
 }
 
 export interface InmateRequest {
@@ -23,7 +23,7 @@ export interface InmateRequest {
   date_processed: string
   action: string
   status: string
-  [key: string]: any
+  [key: string]: unknown
 }
 
 export interface InmateComment {
@@ -31,12 +31,12 @@ export interface InmateComment {
   body: string
   author: string
   datetime_created: string
-  [key: string]: any
+  [key: string]: unknown
 }
 
 export interface InmateSearchResults {
   inmates: Inmate[]
-  errors: any[]
+  errors: unknown[]
 }
 
 export interface Unit {
@@ -49,7 +49,7 @@ export interface Unit {
   state: string
   url?: string
   shipping_method?: string
-  [key: string]: any
+  [key: string]: unknown
 }
 
 async function fetchAPI(url: string, options: RequestInit = {}) {

--- a/src/components/SimpleTable.vue
+++ b/src/components/SimpleTable.vue
@@ -36,27 +36,27 @@ export interface TableColumn {
 
 interface Props {
   columns: TableColumn[]
-  data: any[]
+  data: Record<string, unknown>[]
   rowHover?: boolean
 }
 
 const props = defineProps<Props>()
 const emit = defineEmits(['row-click'])
 
-function onRowClick(item: any) {
+function onRowClick(item: Record<string, unknown>) {
   if (props.rowHover) {
     emit('row-click', item)
   }
 }
 
 // Helper to get nested values using dot notation
-function getNestedValue(obj: any, path: string): any {
+function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
   if (!path) return obj
   const keys = path.split('.')
-  let result = obj
+  let result: unknown = obj
   for (const key of keys) {
     if (result && typeof result === 'object' && key in result) {
-      result = result[key]
+      result = (result as Record<string, unknown>)[key]
     } else {
       return undefined // Or a default value like 'N/A' or null
     }

--- a/src/views/InmateDetailView.vue
+++ b/src/views/InmateDetailView.vue
@@ -69,11 +69,8 @@
 
 <script setup lang="ts">
 import { ref, onMounted, computed, watch } from 'vue'
-import { useRoute } from 'vue-router'
-import { getInmateDetails, type Inmate, type InmateRequest, type InmateComment } from '@/api'
+import { getInmateDetails, type Inmate } from '@/api'
 import SimpleTable, { type TableColumn } from '@/components/SimpleTable.vue'
-
-const route = useRoute()
 const inmate = ref<Inmate | null>(null)
 const isLoading = ref(false)
 const error = ref<string | null>(null)
@@ -123,8 +120,9 @@ async function fetchDetails() {
   error.value = null
   try {
     inmate.value = await getInmateDetails(props.jurisdiction, props.id)
-  } catch (err: any) {
-    error.value = err.message || `Failed to fetch details for inmate ${props.id}.`
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : `Failed to fetch details for inmate ${props.id}.`
+    error.value = message
     inmate.value = null
   } finally {
     isLoading.value = false

--- a/src/views/InmatesSearchView.vue
+++ b/src/views/InmatesSearchView.vue
@@ -62,7 +62,7 @@ const searchQuery = ref('')
 const searchResults = ref<Inmate[]>([])
 const isLoading = ref(false)
 const error = ref<string | null>(null)
-const apiErrors = ref<any[]>([])
+const apiErrors = ref<unknown[]>([])
 const router = useRouter()
 const hasSearched = ref(false)
 
@@ -90,8 +90,9 @@ async function handleSearch() {
     const results: InmateSearchResults = await searchInmates(searchQuery.value)
     searchResults.value = results.inmates
     apiErrors.value = results.errors
-  } catch (err: any) {
-    error.value = err.message || 'Failed to fetch search results.'
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch search results.'
+    error.value = message
     searchResults.value = []
   } finally {
     isLoading.value = false

--- a/src/views/UnitDetailView.vue
+++ b/src/views/UnitDetailView.vue
@@ -28,11 +28,9 @@
 
 <script setup lang="ts">
 import { ref, onMounted, computed, watch } from 'vue'
-import { useRoute } from 'vue-router'
 import { getUnitDetails, type Unit } from '@/api'
 import SimpleTable, { type TableColumn } from '@/components/SimpleTable.vue'
 
-const route = useRoute()
 const unit = ref<Unit | null>(null)
 const isLoading = ref(false)
 const error = ref<string | null>(null)
@@ -64,8 +62,9 @@ async function fetchDetails() {
   error.value = null
   try {
     unit.value = await getUnitDetails(props.jurisdiction, props.name)
-  } catch (err: any) {
-    error.value = err.message || `Failed to fetch details for unit ${props.name}.`
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : `Failed to fetch details for unit ${props.name}.`
+    error.value = message
     unit.value = null
   } finally {
     isLoading.value = false

--- a/src/views/UnitsListView.vue
+++ b/src/views/UnitsListView.vue
@@ -48,8 +48,9 @@ async function fetchUnitsData() {
   error.value = null
   try {
     units.value = await getAllUnits()
-  } catch (err: any) {
-    error.value = err.message || 'Failed to fetch units.'
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch units.'
+    error.value = message
     units.value = []
   } finally {
     isLoading.value = false


### PR DESCRIPTION
## Summary
- remove unused imports
- add strict error typing for components
- use `unknown` instead of `any` in api types
- make `SimpleTable` generic-friendly

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684d9a759cfc8325a846fe1f15f442d6