### PR TITLE
Implement all API endpoints

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,27 +1,27 @@
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000'
 
-// Define interfaces based on your FastAPI schemas
-export interface Inmate {
-  id: number
-  jurisdiction: string
-  first_name: string
-  last_name: string
-  race?: string
-  sex?: string
-  release?: string | Date
-  url?: string
-  datetime_fetched?: string
-  unit?: Unit
-  requests?: InmateRequest[]
-  comments?: InmateComment[]
+// Enumerations from the API schema
+export type Jurisdiction = 'Texas' | 'Federal'
+export type Action = 'Filled' | 'Tossed'
+export type ShippingMethod = 'Box' | 'Individual'
+
+// Interfaces based on the FastAPI schemas
+export interface Lookup {
+  datetime_created: string
 }
 
 export interface InmateRequest {
   index: number
   date_postmarked: string
   date_processed: string
-  action: string
+  action: Action
   status: string
+}
+
+export interface RequestCreate {
+  date_postmarked: string
+  date_processed: string
+  action: Action
 }
 
 export interface InmateComment {
@@ -31,21 +31,66 @@ export interface InmateComment {
   datetime_created: string
 }
 
-export interface InmateSearchResults {
-  inmates: Inmate[]
-  errors: string[]
+export interface CommentCreate {
+  body: string
+  author: string
+  datetime_created: string
 }
 
 export interface Unit {
   name: string
-  jurisdiction: string
+  jurisdiction: Jurisdiction
   street1: string
-  street2?: string
+  street2?: string | null
   city: string
   zipcode: string
   state: string
-  url?: string
-  shipping_method?: string
+  url?: string | null
+  shipping_method?: ShippingMethod | null
+}
+
+export interface UnitUpdate {
+  name?: string | null
+  street1?: string | null
+  street2?: string | null
+  city?: string | null
+  zipcode?: string | null
+  state?: string | null
+  url?: string | null
+  jurisdiction?: Jurisdiction | null
+  shipping_method?: ShippingMethod | null
+}
+
+export interface Inmate {
+  first_name?: string | null
+  last_name?: string | null
+  jurisdiction: Jurisdiction
+  id: number
+  race?: string | null
+  sex?: string | null
+  release?: string | null
+  url?: string | null
+  datetime_fetched?: string | null
+  unit: Unit
+  requests?: InmateRequest[]
+  comments?: InmateComment[]
+  lookups?: Lookup[]
+}
+
+export interface InmateSearchResult {
+  first_name?: string | null
+  last_name?: string | null
+  jurisdiction: Jurisdiction
+  id: number
+  race?: string | null
+  sex?: string | null
+  release?: string | null
+  url?: string | null
+}
+
+export interface InmateSearchResults {
+  inmates: InmateSearchResult[]
+  errors: string[]
 }
 
 async function fetchAPI(url: string, options: RequestInit = {}) {
@@ -53,6 +98,9 @@ async function fetchAPI(url: string, options: RequestInit = {}) {
   if (!response.ok) {
     const errorData = await response.json().catch(() => ({ detail: response.statusText }))
     throw new Error(errorData.detail || `HTTP error! status: ${response.status}`)
+  }
+  if (response.status === 204) {
+    return
   }
   return response.json()
 }
@@ -71,4 +119,62 @@ export async function getAllUnits(): Promise<Unit[]> {
 
 export async function getUnitDetails(jurisdiction: string, name: string): Promise<Unit> {
   return fetchAPI(`/units/${jurisdiction}/${encodeURIComponent(name)}`)
+}
+
+export async function addRequest(
+  jurisdiction: string,
+  inmateId: number,
+  data: RequestCreate,
+): Promise<InmateRequest> {
+  return fetchAPI(`/inmates/${encodeURIComponent(jurisdiction)}/${inmateId}/requests`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+}
+
+export async function deleteRequest(
+  jurisdiction: string,
+  inmateId: number,
+  requestIndex: number,
+): Promise<void> {
+  await fetchAPI(
+    `/inmates/${encodeURIComponent(jurisdiction)}/${inmateId}/requests/${requestIndex}`,
+    { method: 'DELETE' },
+  )
+}
+
+export async function addComment(
+  jurisdiction: string,
+  inmateId: number,
+  data: CommentCreate,
+): Promise<InmateComment> {
+  return fetchAPI(`/inmates/${encodeURIComponent(jurisdiction)}/${inmateId}/comments`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+}
+
+export async function deleteComment(
+  jurisdiction: string,
+  inmateId: number,
+  commentIndex: number,
+): Promise<void> {
+  await fetchAPI(
+    `/inmates/${encodeURIComponent(jurisdiction)}/${inmateId}/comments/${commentIndex}`,
+    { method: 'DELETE' },
+  )
+}
+
+export async function updateUnit(
+  jurisdiction: string,
+  name: string,
+  data: UnitUpdate,
+): Promise<Unit> {
+  return fetchAPI(`/units/${encodeURIComponent(jurisdiction)}/${encodeURIComponent(name)}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
 }


### PR DESCRIPTION
## Summary
- expand `api.ts` with enums and interfaces that mirror the OpenAPI schema
- add helper for 204 responses
- add methods for creating/deleting requests & comments and for updating units

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684da708f19083259bf9b3b24499f818