### PR TITLE
Add inline deletion UI for requests and comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@heroicons/vue": "^2.2.0",
         "@tailwindcss/vite": "^4.1.8",
         "tailwindcss": "^4.1.8",
         "vue": "^3.5.13",
@@ -1113,6 +1114,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@heroicons/vue": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/vue/-/vue-2.2.0.tgz",
+      "integrity": "sha512-G3dbSxoeEKqbi/DFalhRxJU4mTXJn7GwZ7ae8NuEQzd1bqdd0jAbdaBZlHPcvPD2xI1iGzNVB4k20Un2AguYPw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": ">= 3"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "@tailwindcss/vite": "^4.1.8",
     "tailwindcss": "^4.1.8",
     "vue": "^3.5.13",
-    "vue-router": "^4.5.0"
+    "vue-router": "^4.5.0",
+    "@heroicons/vue": "^2.2.0"
   },
   "devDependencies": {
     "@tsconfig/node22": "^22.0.1",

--- a/src/views/InmateDetailView.vue
+++ b/src/views/InmateDetailView.vue
@@ -55,11 +55,43 @@
               Create Request
             </button>
           </div>
-          <simple-table
-            v-if="inmate.requests && inmate.requests.length > 0"
-            :columns="requestsTableColumns"
-            :data="inmate.requests"
-          />
+          <div v-if="inmate.requests && inmate.requests.length > 0" class="simple-table-container">
+            <table class="simple-table">
+              <thead>
+                <tr>
+                  <th v-for="col in requestsTableColumns" :key="col.key">{{ col.label }}</th>
+                  <th>Delete</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="(req, i) in inmate.requests" :key="req.index">
+                  <td>{{ req.index }}</td>
+                  <td>{{ req.date_postmarked }}</td>
+                  <td>{{ req.date_processed }}</td>
+                  <td>{{ req.action }}</td>
+                  <td>{{ req.status }}</td>
+                  <td>
+                    <button
+                      v-if="confirmRequestIndex !== i"
+                      @click="confirmRequestIndex = i"
+                      aria-label="Delete request"
+                    >
+                      <TrashIcon class="w-5 h-5 text-red-600" />
+                    </button>
+                    <div v-else class="flex items-center gap-1">
+                      <span class="mr-1">Are you sure?</span>
+                      <button @click="confirmDeleteRequest(i)" aria-label="Confirm delete">
+                        <CheckIcon class="w-5 h-5 text-green-600" />
+                      </button>
+                      <button @click="confirmRequestIndex = null" aria-label="Cancel delete">
+                        <XMarkIcon class="w-5 h-5 text-gray-600" />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
           <p v-else>No requests found for this inmate.</p>
         </section>
 
@@ -73,11 +105,42 @@
               Create Comment
             </button>
           </div>
-          <simple-table
-            v-if="inmate.comments && inmate.comments.length > 0"
-            :columns="commentsTableColumns"
-            :data="inmate.comments"
-          />
+          <div v-if="inmate.comments && inmate.comments.length > 0" class="simple-table-container">
+            <table class="simple-table">
+              <thead>
+                <tr>
+                  <th v-for="col in commentsTableColumns" :key="col.key">{{ col.label }}</th>
+                  <th>Delete</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="(cmt, i) in inmate.comments" :key="cmt.index">
+                  <td>{{ cmt.index }}</td>
+                  <td>{{ cmt.datetime_created }}</td>
+                  <td>{{ cmt.body }}</td>
+                  <td>{{ cmt.author }}</td>
+                  <td>
+                    <button
+                      v-if="confirmCommentIndex !== i"
+                      @click="confirmCommentIndex = i"
+                      aria-label="Delete comment"
+                    >
+                      <TrashIcon class="w-5 h-5 text-red-600" />
+                    </button>
+                    <div v-else class="flex items-center gap-1">
+                      <span class="mr-1">Are you sure?</span>
+                      <button @click="confirmDeleteComment(i)" aria-label="Confirm delete">
+                        <CheckIcon class="w-5 h-5 text-green-600" />
+                      </button>
+                      <button @click="confirmCommentIndex = null" aria-label="Cancel delete">
+                        <XMarkIcon class="w-5 h-5 text-gray-600" />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
           <p v-else>No comments found for this inmate.</p>
         </section>
         <BaseModal :show="showCommentModal" @close="closeCommentModal">
@@ -111,8 +174,11 @@ import {
   getInmateDetails,
   addRequest,
   addComment,
+  deleteRequest,
+  deleteComment,
   type Inmate,
 } from '@/api'
+import { TrashIcon, CheckIcon, XMarkIcon } from '@heroicons/vue/24/solid'
 import SimpleTable, { type TableColumn } from '@/components/SimpleTable.vue'
 import BaseModal from '@/components/BaseModal.vue'
 const inmate = ref<Inmate | null>(null)
@@ -137,6 +203,8 @@ const showCommentModal = ref(false)
 const commentAuthor = ref('')
 const commentBody = ref('')
 const commentDate = ref('')
+const confirmRequestIndex = ref<number | null>(null)
+const confirmCommentIndex = ref<number | null>(null)
 
 watch(postmarkDate, (val) => setCookie('postmarkDate', val))
 
@@ -250,6 +318,34 @@ async function createComment() {
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'Failed to create comment.'
     error.value = message
+  }
+}
+
+async function confirmDeleteRequest(idx: number) {
+  if (!inmate.value || !inmate.value.requests) return
+  try {
+    const req = inmate.value.requests[idx]
+    await deleteRequest(inmate.value.jurisdiction, inmate.value.id, req.index)
+    inmate.value.requests.splice(idx, 1)
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Failed to delete request.'
+    error.value = message
+  } finally {
+    confirmRequestIndex.value = null
+  }
+}
+
+async function confirmDeleteComment(idx: number) {
+  if (!inmate.value || !inmate.value.comments) return
+  try {
+    const cmt = inmate.value.comments[idx]
+    await deleteComment(inmate.value.jurisdiction, inmate.value.id, cmt.index)
+    inmate.value.comments.splice(idx, 1)
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Failed to delete comment.'
+    error.value = message
+  } finally {
+    confirmCommentIndex.value = null
   }
 }
 

--- a/src/views/InmateDetailView.vue
+++ b/src/views/InmateDetailView.vue
@@ -55,28 +55,31 @@
               Create Request
             </button>
           </div>
-          <div v-if="inmate.requests && inmate.requests.length > 0" class="simple-table-container">
-            <table class="simple-table">
-              <thead>
+          <div v-if="inmate.requests && inmate.requests.length > 0" class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-300">
+              <thead class="bg-gray-50 dark:bg-gray-700">
                 <tr>
-                  <th v-for="col in requestsTableColumns" :key="col.key">{{ col.label }}</th>
-                  <th>Delete</th>
+                  <th v-for="col in requestsTableColumns" :key="col.key" class="px-4 py-2 text-left text-sm font-semibold text-gray-900 dark:text-gray-100">
+                    {{ col.label }}
+                  </th>
+                  <th class="w-12"></th>
                 </tr>
               </thead>
-              <tbody>
-                <tr v-for="(req, i) in inmate.requests" :key="req.index">
-                  <td>{{ req.index }}</td>
-                  <td>{{ req.date_postmarked }}</td>
-                  <td>{{ req.date_processed }}</td>
-                  <td>{{ req.action }}</td>
-                  <td>{{ req.status }}</td>
-                  <td>
+              <tbody class="divide-y divide-gray-200 dark:divide-gray-600">
+                <tr v-for="(req, i) in inmate.requests" :key="req.index" class="group">
+                  <td class="px-4 py-2">{{ req.index }}</td>
+                  <td class="px-4 py-2">{{ req.date_postmarked }}</td>
+                  <td class="px-4 py-2">{{ req.date_processed }}</td>
+                  <td class="px-4 py-2">{{ req.action }}</td>
+                  <td class="px-4 py-2">{{ req.status }}</td>
+                  <td class="px-4 py-2">
                     <button
                       v-if="confirmRequestIndex !== i"
                       @click="confirmRequestIndex = i"
                       aria-label="Delete request"
+                      class="text-red-600 opacity-0 group-hover:opacity-100"
                     >
-                      <TrashIcon class="w-5 h-5 text-red-600" />
+                      <TrashIcon class="w-5 h-5" />
                     </button>
                     <div v-else class="flex items-center gap-1">
                       <span class="mr-1">Are you sure?</span>
@@ -105,27 +108,30 @@
               Create Comment
             </button>
           </div>
-          <div v-if="inmate.comments && inmate.comments.length > 0" class="simple-table-container">
-            <table class="simple-table">
-              <thead>
+          <div v-if="inmate.comments && inmate.comments.length > 0" class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-300">
+              <thead class="bg-gray-50 dark:bg-gray-700">
                 <tr>
-                  <th v-for="col in commentsTableColumns" :key="col.key">{{ col.label }}</th>
-                  <th>Delete</th>
+                  <th v-for="col in commentsTableColumns" :key="col.key" class="px-4 py-2 text-left text-sm font-semibold text-gray-900 dark:text-gray-100">
+                    {{ col.label }}
+                  </th>
+                  <th class="w-12"></th>
                 </tr>
               </thead>
-              <tbody>
-                <tr v-for="(cmt, i) in inmate.comments" :key="cmt.index">
-                  <td>{{ cmt.index }}</td>
-                  <td>{{ cmt.datetime_created }}</td>
-                  <td>{{ cmt.body }}</td>
-                  <td>{{ cmt.author }}</td>
-                  <td>
+              <tbody class="divide-y divide-gray-200 dark:divide-gray-600">
+                <tr v-for="(cmt, i) in inmate.comments" :key="cmt.index" class="group">
+                  <td class="px-4 py-2">{{ cmt.index }}</td>
+                  <td class="px-4 py-2">{{ cmt.datetime_created }}</td>
+                  <td class="px-4 py-2">{{ cmt.body }}</td>
+                  <td class="px-4 py-2">{{ cmt.author }}</td>
+                  <td class="px-4 py-2">
                     <button
                       v-if="confirmCommentIndex !== i"
                       @click="confirmCommentIndex = i"
                       aria-label="Delete comment"
+                      class="text-red-600 opacity-0 group-hover:opacity-100"
                     >
-                      <TrashIcon class="w-5 h-5 text-red-600" />
+                      <TrashIcon class="w-5 h-5" />
                     </button>
                     <div v-else class="flex items-center gap-1">
                       <span class="mr-1">Are you sure?</span>


### PR DESCRIPTION
## Summary
- add `@heroicons/vue` dependency for icons
- integrate hero icons into inmate detail view
- include inline row confirmations for deleting requests/comments
- call backend delete API and update arrays reactively

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_684dbe5558b48325a04e7cac68ae4c57