### PR TITLE
Incorporate unit info in inmate view

### DIFF
--- a/src/components/SimpleTable.vue
+++ b/src/components/SimpleTable.vue
@@ -14,11 +14,13 @@
           :class="{ 'clickable-row': rowHover }"
         >
           <td v-for="column in columns" :key="`${rowIndex}-${column.key}`">
-            {{
-              getNestedValue(item, column.key) !== undefined
-                ? getNestedValue(item, column.key)
-                : 'N/A'
-            }}
+            <span
+              v-html="
+                getNestedValue(item, column.key) !== undefined
+                  ? String(getNestedValue(item, column.key))
+                  : 'N/A'
+              "
+            />
           </td>
         </tr>
       </tbody>

--- a/src/views/InmateDetailView.vue
+++ b/src/views/InmateDetailView.vue
@@ -25,23 +25,6 @@
           <simple-table :columns="inmateInfoColumns" :data="[inmateInfoForTable]" />
         </section>
 
-        <section
-          class="bg-white dark:bg-gray-800 p-4 rounded shadow w-full md:w-[48%]"
-          v-if="inmate.unit"
-        >
-          <h2 class="text-xl font-semibold mb-2">Assigned Unit</h2>
-          <p>
-            <router-link
-              :to="{
-                name: 'unit-detail',
-                params: { jurisdiction: inmate.unit.jurisdiction, name: inmate.unit.name },
-              }"
-              class="text-blue-600 hover:underline"
-            >
-              {{ inmate.unit.name }} ({{ inmate.unit.jurisdiction }})
-            </router-link>
-          </p>
-        </section>
 
         <section class="bg-white dark:bg-gray-800 p-4 rounded shadow w-full md:w-[48%]">
           <h2 class="text-xl font-semibold mb-2">Requests</h2>
@@ -140,6 +123,16 @@ const commentDate = ref('')
 
 watch(postmarkDate, (val) => setCookie('postmarkDate', val))
 
+function createUrlAnchor(url: string | null | undefined): string {
+  if (!url) return ''
+  const text = url.includes('tdcj.texas.gov')
+    ? 'TDCJ Page'
+    : url.includes('bop.gov')
+      ? 'FBOP page'
+      : url
+  return `<a href="${url}" target="_blank" rel="noopener">${text}</a>`
+}
+
 const props = defineProps<{
   jurisdiction: string
   id: string
@@ -155,6 +148,15 @@ const inmateInfoColumns: TableColumn[] = [
   { key: 'release', label: 'Release' },
   { key: 'url', label: 'URL' },
   { key: 'datetime_fetched', label: 'Fetched At' },
+  { key: 'unit_name', label: 'Unit Name' },
+  { key: 'unit_jurisdiction', label: 'Unit Jurisdiction' },
+  { key: 'unit_street1', label: 'Unit Street 1' },
+  { key: 'unit_street2', label: 'Unit Street 2' },
+  { key: 'unit_city', label: 'Unit City' },
+  { key: 'unit_state', label: 'Unit State' },
+  { key: 'unit_zipcode', label: 'Unit Zipcode' },
+  { key: 'unit_url', label: 'Unit URL' },
+  { key: 'unit_shipping_method', label: 'Unit Shipping Method' },
 ]
 
 const requestsTableColumns: TableColumn[] = [
@@ -183,8 +185,17 @@ const inmateInfoForTable = computed(() => {
     race: inmate.value.race,
     sex: inmate.value.sex,
     release: inmate.value.release,
-    url: inmate.value.url,
+    url: createUrlAnchor(inmate.value.url),
     datetime_fetched: inmate.value.datetime_fetched,
+    unit_name: inmate.value.unit?.name,
+    unit_jurisdiction: inmate.value.unit?.jurisdiction,
+    unit_street1: inmate.value.unit?.street1,
+    unit_street2: inmate.value.unit?.street2,
+    unit_city: inmate.value.unit?.city,
+    unit_state: inmate.value.unit?.state,
+    unit_zipcode: inmate.value.unit?.zipcode,
+    unit_url: createUrlAnchor(inmate.value.unit?.url),
+    unit_shipping_method: inmate.value.unit?.shipping_method,
   }
 })
 

--- a/src/views/InmateDetailView.vue
+++ b/src/views/InmateDetailView.vue
@@ -123,14 +123,19 @@ const commentDate = ref('')
 
 watch(postmarkDate, (val) => setCookie('postmarkDate', val))
 
-function createUrlAnchor(url: string | null | undefined): string {
-  if (!url) return ''
-  const text = url.includes('tdcj.texas.gov')
-    ? 'TDCJ Page'
-    : url.includes('bop.gov')
-      ? 'FBOP page'
-      : url
-  return `<a href="${url}" target="_blank" rel="noopener">${text}</a>`
+function createUrlAnchor(
+  url: string | null | undefined,
+  text?: string
+): string {
+  if (!url) return text || ''
+  const label =
+    text ||
+    (url.includes('tdcj.texas.gov')
+      ? 'TDCJ Page'
+      : url.includes('bop.gov')
+        ? 'FBOP page'
+        : url)
+  return `<a href="${url}" target="_blank" rel="noopener">${label}</a>`
 }
 
 const props = defineProps<{
@@ -141,22 +146,12 @@ const props = defineProps<{
 const inmateInfoColumns: TableColumn[] = [
   { key: 'id', label: 'Inmate ID' },
   { key: 'jurisdiction', label: 'Jurisdiction' },
-  { key: 'first_name', label: 'First Name' },
-  { key: 'last_name', label: 'Last Name' },
+  { key: 'name', label: 'Name' },
   { key: 'race', label: 'Race' },
   { key: 'sex', label: 'Sex' },
   { key: 'release', label: 'Release' },
-  { key: 'url', label: 'URL' },
   { key: 'datetime_fetched', label: 'Fetched At' },
   { key: 'unit_name', label: 'Unit Name' },
-  { key: 'unit_jurisdiction', label: 'Unit Jurisdiction' },
-  { key: 'unit_street1', label: 'Unit Street 1' },
-  { key: 'unit_street2', label: 'Unit Street 2' },
-  { key: 'unit_city', label: 'Unit City' },
-  { key: 'unit_state', label: 'Unit State' },
-  { key: 'unit_zipcode', label: 'Unit Zipcode' },
-  { key: 'unit_url', label: 'Unit URL' },
-  { key: 'unit_shipping_method', label: 'Unit Shipping Method' },
 ]
 
 const requestsTableColumns: TableColumn[] = [
@@ -180,22 +175,18 @@ const inmateInfoForTable = computed(() => {
   return {
     id: inmate.value.id,
     jurisdiction: inmate.value.jurisdiction,
-    first_name: inmate.value.first_name,
-    last_name: inmate.value.last_name,
+    name: createUrlAnchor(
+      inmate.value.url,
+      `${inmate.value.first_name ?? ''} ${inmate.value.last_name ?? ''}`.trim()
+    ),
     race: inmate.value.race,
     sex: inmate.value.sex,
     release: inmate.value.release,
-    url: createUrlAnchor(inmate.value.url),
     datetime_fetched: inmate.value.datetime_fetched,
-    unit_name: inmate.value.unit?.name,
-    unit_jurisdiction: inmate.value.unit?.jurisdiction,
-    unit_street1: inmate.value.unit?.street1,
-    unit_street2: inmate.value.unit?.street2,
-    unit_city: inmate.value.unit?.city,
-    unit_state: inmate.value.unit?.state,
-    unit_zipcode: inmate.value.unit?.zipcode,
-    unit_url: createUrlAnchor(inmate.value.unit?.url),
-    unit_shipping_method: inmate.value.unit?.shipping_method,
+    unit_name: createUrlAnchor(
+      inmate.value.unit?.url,
+      inmate.value.unit?.name || ''
+    ),
   }
 })
 

--- a/src/views/UnitDetailView.vue
+++ b/src/views/UnitDetailView.vue
@@ -35,6 +35,16 @@ const unit = ref<Unit | null>(null)
 const isLoading = ref(false)
 const error = ref<string | null>(null)
 
+function createUrlAnchor(url: string | null | undefined): string {
+  if (!url) return ''
+  const text = url.includes('tdcj.texas.gov')
+    ? 'TDCJ Page'
+    : url.includes('bop.gov')
+      ? 'FBOP page'
+      : url
+  return `<a href="${url}" target="_blank" rel="noopener">${text}</a>`
+}
+
 const props = defineProps<{
   jurisdiction: string
   name: string
@@ -62,7 +72,7 @@ const unitInfoForTable = computed(() => {
     city: unit.value.city,
     state: unit.value.state,
     zipcode: unit.value.zipcode,
-    url: unit.value.url,
+    url: createUrlAnchor(unit.value.url),
     shipping_method: unit.value.shipping_method,
   }
 })

--- a/src/views/UnitDetailView.vue
+++ b/src/views/UnitDetailView.vue
@@ -35,14 +35,19 @@ const unit = ref<Unit | null>(null)
 const isLoading = ref(false)
 const error = ref<string | null>(null)
 
-function createUrlAnchor(url: string | null | undefined): string {
-  if (!url) return ''
-  const text = url.includes('tdcj.texas.gov')
-    ? 'TDCJ Page'
-    : url.includes('bop.gov')
-      ? 'FBOP page'
-      : url
-  return `<a href="${url}" target="_blank" rel="noopener">${text}</a>`
+function createUrlAnchor(
+  url: string | null | undefined,
+  text?: string
+): string {
+  if (!url) return text || ''
+  const label =
+    text ||
+    (url.includes('tdcj.texas.gov')
+      ? 'TDCJ Page'
+      : url.includes('bop.gov')
+        ? 'FBOP page'
+        : url)
+  return `<a href="${url}" target="_blank" rel="noopener">${label}</a>`
 }
 
 const props = defineProps<{


### PR DESCRIPTION
## Summary
- render table cells as HTML so we can use anchors
- show unit details inside the inmate info table
- show human-friendly anchor text for URLs

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_684df33b1a848325853d2adbbc10a93d