### PR TITLE
Add max height for detail tables

### DIFF
--- a/src/views/InmateDetailView.vue
+++ b/src/views/InmateDetailView.vue
@@ -43,7 +43,7 @@
           </p>
         </section>
 
-        <section class="bg-white dark:bg-gray-800 p-4 rounded shadow w-full md:w-[48%]">
+        <section class="bg-white dark:bg-gray-800 p-4 rounded shadow w-full md:w-[48%] overflow-y-auto max-h-96">
           <h2 class="text-xl font-semibold mb-2">Requests</h2>
           <div class="flex items-center gap-2 mb-2">
             <input type="date" v-model="postmarkDate" class="border p-1 rounded" />
@@ -63,7 +63,7 @@
           <p v-else>No requests found for this inmate.</p>
         </section>
 
-        <section class="bg-white dark:bg-gray-800 p-4 rounded shadow w-full md:w-[48%]">
+        <section class="bg-white dark:bg-gray-800 p-4 rounded shadow w-full md:w-[48%] overflow-y-auto max-h-96">
           <h2 class="text-xl font-semibold mb-2">Comments</h2>
           <div class="flex items-center gap-2 mb-2">
             <button


### PR DESCRIPTION
## Summary
- limit the size of requests and comments sections on the inmate detail view

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_684df387c4408325bd885c518e7e2d77