### PR TITLE
Improve inmate data display

### DIFF
--- a/src/views/InmateDetailView.vue
+++ b/src/views/InmateDetailView.vue
@@ -21,7 +21,16 @@
           <div class="card flex-fill">
             <div class="card-body">
               <h2 class="h5 fw-semibold mb-2">Inmate Data</h2>
-              <simple-table :columns="inmateInfoColumns" :data="[inmateInfoForTable]" />
+              <ul class="list-unstyled mb-0">
+                <li
+                  v-for="(item, idx) in inmateInfoList"
+                  :key="idx"
+                  class="mb-2 text-start"
+                >
+                  <div class="fw-semibold">{{ item.label }}</div>
+                  <div class="text-start" v-html="item.value !== undefined ? item.value : 'N/A'" />
+                </li>
+              </ul>
             </div>
           </div>
         </div>
@@ -168,7 +177,7 @@ import {
   type Inmate,
 } from '@/api'
 import { TrashIcon, CheckIcon, XMarkIcon } from '@heroicons/vue/24/solid'
-import SimpleTable, { type TableColumn } from '@/components/SimpleTable.vue'
+import type { TableColumn } from '@/components/SimpleTable.vue'
 import BaseModal from '@/components/BaseModal.vue'
 const inmate = ref<Inmate | null>(null)
 const isLoading = ref(false)
@@ -249,6 +258,14 @@ const inmateInfoForTable = computed(() => {
     datetime_fetched: inmate.value.datetime_fetched,
     unit_name: createUrlAnchor(inmate.value.unit?.url, inmate.value.unit?.name || ''),
   }
+})
+
+const inmateInfoList = computed(() => {
+  const info = inmateInfoForTable.value as Record<string, unknown>
+  return inmateInfoColumns.map((col) => ({
+    label: col.label,
+    value: info[col.key],
+  }))
 })
 
 function sortRequests() {


### PR DESCRIPTION
## Summary
- render inmate data as a list of key-value pairs
- compute a list of label/value pairs for the inmate detail view

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e191eb3908325b78a53fecd9f92c0